### PR TITLE
Alternative implementation to process short folder name

### DIFF
--- a/Assemblers.Common/PackageReferenceProcessor.cs
+++ b/Assemblers.Common/PackageReferenceProcessor.cs
@@ -337,9 +337,24 @@
             }
 
             var nearestLibItems = libItems.FirstOrDefault(x => x.TargetFramework.Equals(nearestVersion));
-            var shortFolderName = nearestVersion.GetShortFolderName();
 
-            if (nearestLibItems == null)
+            if (nearestLibItems?.Items == null || !nearestLibItems.Items.Any())
+            {
+                return Array.Empty<string>();
+            }
+
+            // Determine short folder name as follows because nearestVersion.GetShortFolderName(); could give a different result (e.g. net40) compared to what is used in the actual package (e.g. net4).
+            var firstItem = nearestLibItems.Items.First();
+            var firstItemParts = firstItem.Split('/');
+
+            string shortFolderName = null;
+
+            if(firstItemParts.Length > 1)
+            {
+                shortFolderName = firstItemParts[1];
+            }
+
+            if(shortFolderName == null)
             {
                 return Array.Empty<string>();
             }
@@ -355,6 +370,7 @@
 
                 string prefix = "lib/" + shortFolderName + '/';
 
+                // Safeguard.
                 if (!libItem.StartsWith(prefix))
                 {
                     continue;

--- a/Assemblers.ProtocolTests/ProtocolBuilderTests.cs
+++ b/Assemblers.ProtocolTests/ProtocolBuilderTests.cs
@@ -41,6 +41,24 @@
         }
 
         [TestMethod]
+        public async Task ProtocolBuilder_BuildAsync_KeepReferenceAssemblies()
+        {
+            var logCollector = new Logging(true);
+
+            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var dir = Path.GetFullPath(Path.Combine(baseDir, @"TestFiles\Protocol\Solution3"));
+            var solutionFilePath = Path.Combine(dir, "protocol.sln");
+
+            ProtocolSolution solution = ProtocolSolution.Load(solutionFilePath, logCollector);
+            ProtocolBuilder protocolBuilder = new ProtocolBuilder(solution, logCollector);
+
+            var buildResultItems = await protocolBuilder.BuildAsync();
+
+            Assert.IsNotNull(buildResultItems.Assemblies);
+            Assert.AreEqual(18, buildResultItems.Assemblies.Count);
+        }
+
+        [TestMethod]
         public async Task ProtocolCompiler_ProtocolBuilder_BasicAsync()
         {
             string originalProtocol = @"<Protocol>


### PR DESCRIPTION
nearestVersion.GetShortFolderName(); could give a different result (e.g. net40) compared to what is used in the actual package (e.g. net4).